### PR TITLE
Unify features in Material Kit React

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# openhub
+# OpenHub
+
+This repository combines several features into a single React frontend.
+
+## Unified React Frontend
+
+The [`material-kit-react`](./material-kit-react) project contains routes for:
+
+- Trivia generation from uploaded PDFs
+- Meshy text-to-3D model generation
+- Obstacle generator using the Flask API
+
+Run the frontend locally with:
+
+```bash
+cd material-kit-react
+npm install
+npm start
+```
+
+Ensure the Flask services in `backend` and `obstacle_generation` are running so the pages can reach their APIs.

--- a/material-kit-react/.env.sample
+++ b/material-kit-react/.env.sample
@@ -1,0 +1,1 @@
+REACT_APP_MESHY_KEY=your_meshy_api_key

--- a/material-kit-react/README.md
+++ b/material-kit-react/README.md
@@ -214,3 +214,16 @@ Dribbble: <https://dribbble.com/creativetim>
 Google+: <https://plus.google.com/+CreativetimPage>
 
 Instagram: <https://instagram.com/creativetimofficial>
+
+## Local Setup
+
+1. Navigate to `material-kit-react` and install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy `.env.sample` to `.env` and fill in your API keys.
+3. Start the development server:
+   ```bash
+   npm start
+   ```
+

--- a/material-kit-react/src/App.js
+++ b/material-kit-react/src/App.js
@@ -1,325 +1,36 @@
-import React, { useState } from "react";
-import axios from "axios";
-import {
-  Button,
-  Typography,
-  Container,
-  Box,
-  Paper,
-  CircularProgress,
-  Alert,
-  Grid,
-  Card,
-  CardContent,
-  List,
-  ListItem,
-  ListItemText,
-  AppBar,
-  Toolbar,
-  IconButton,
-  Avatar,
-  Snackbar,
-  Skeleton,
-} from "@mui/material";
-import { CloudUpload as CloudUploadIcon, Menu as MenuIcon } from "@mui/icons-material";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
-import { motion } from "framer-motion";
-import Logo from "./assets/images/LV (2).png"; // Correct path for logo
-
-const theme = createTheme({
-  palette: {
-    mode: "dark",
-    primary: {
-      main: "#00bcd4",
-    },
-    secondary: {
-      main: "#ff4081",
-    },
-    background: {
-      default: "#121212",
-      paper: "rgba(255, 255, 255, 0.08)",
-    },
-  },
-  typography: {
-    fontFamily: "Poppins, Arial, sans-serif",
-    h6: {
-      fontWeight: 700,
-    },
-  },
-});
+import React from "react";
+import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
+import TriviaPage from "./pages/TriviaPage";
+import MeshyPage from "./pages/MeshyPage";
+import ObstaclePage from "./pages/ObstaclePage";
+import { AppBar, Toolbar, Button } from "@mui/material";
 
 function App() {
-  const [file, setFile] = useState(null);
-  const [context, setContext] = useState("");
-  const [questions, setQuestions] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [statusMessage, setStatusMessage] = useState("");
-  const [error, setError] = useState("");
-  const [openSnackbar, setOpenSnackbar] = useState(false);
-
-  const handleFileChange = (event) => {
-    setFile(event.target.files[0]);
-  };
-
-  const handleSubmit = async (event) => {
-    event.preventDefault();
-    if (!file) {
-      alert("Please upload a file!");
-      return;
-    }
-
-    setLoading(true);
-    setStatusMessage("Extracting text from PDF...");
-    setError("");
-
-    const formData = new FormData();
-    formData.append("file", file);
-
-    try {
-      const response = await axios.post("http://127.0.0.1:5000/process-pdf", formData, {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-      });
-
-      if (response.data.status === "text_extracted") {
-        setStatusMessage("Text extracted successfully!");
-        setContext(response.data.context);
-
-        setStatusMessage("Generating questions...");
-        const questionResponse = await axios.post(
-          "http://127.0.0.1:5000/generate-questions",
-          { context: response.data.context }
-        );
-
-        if (questionResponse.data.status === "questions_generated") {
-          setStatusMessage("Questions generated successfully!");
-          setQuestions(questionResponse.data.questions);
-        } else {
-          setStatusMessage("Failed to generate questions.");
-        }
-      }
-    } catch (error) {
-      console.error("Error processing PDF:", error);
-      setStatusMessage("");
-      setError("Failed to process PDF!");
-    } finally {
-      setLoading(false);
-      setOpenSnackbar(true);
-    }
-  };
-
   return (
-    <ThemeProvider theme={theme}>
-      <Container maxWidth="md" sx={{ padding: "20px", borderRadius: 2 }}>
-        {/* Navbar */}
-        <AppBar position="static" sx={{ marginBottom: "20px", backgroundColor: "#181818", padding: "20px 0" }}>
-  <Toolbar sx={{ flexDirection: "column", alignItems: "center" }}>
-    {/* Logo */}
-    <>
-  {/* Keyframes for Animation */}
-  <style>
-    {`
-      @keyframes pulse {
-        0% {
-          transform: scale(1);
-        }
-        50% {
-          transform: scale(1.1);
-        }
-        100% {
-          transform: scale(1);
-        }
-      }
-    `}
-  </style>
-
-  <img
-    src={Logo}
-    alt="Logo"
-    style={{
-      width: "60px",
-      marginBottom: "10px",
-      animation: "pulse 2s infinite ease-in-out",
-    }}
-  />
-</>
-
-
-    {/* Title */}
-    <Typography
-  variant="h4"
-  component={motion.div}
-  initial={{ opacity: 0, scale: 0.8 }}
-  animate={{ opacity: 1, scale: 1 }}
-  transition={{ duration: 0.5 }}
-  sx={{
-    fontWeight: "bold",
-    fontSize: "2.5rem",
-    background: "linear-gradient(90deg, #1E90FF, #00BFFF, #87CEFA)", // Updated colors
-    WebkitBackgroundClip: "text",
-    WebkitTextFillColor: "transparent",
-    textAlign: "center",
-    textShadow: "0px 0px 10px rgba(30, 144, 255, 0.6), 0px 0px 10px rgba(0, 191, 255, 0.6)", // Matches website theme
-    border: "2px solid rgba(255, 255, 255, 0.1)",
-    borderRadius: "10px",
-    padding: "10px 20px",
-  }}
->
-  Lidvizion's Trivia Generator
-</Typography>
-
-
-
-
-
-  </Toolbar>
-</AppBar>
-
-
-
-
-        {/* File Upload Section */}
-        <Paper elevation={4} sx={{ padding: "30px", marginBottom: "30px", borderRadius: 3 }}>
-          <Typography
-            variant="h6"
-            gutterBottom
-            component={motion.div}
-            initial={{ opacity: 0, y: -10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
-          >
-            Upload a PDF to Generate Trivia Questions
-          </Typography>
-          <form onSubmit={handleSubmit}>
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                border: "1px solid #ccc",
-                padding: "10px",
-                borderRadius: "5px",
-              }}
-            >
-              <CloudUploadIcon sx={{ marginRight: "10px" }} />
-              <input
-                type="file"
-                accept="application/pdf"
-                onChange={handleFileChange}
-                style={{ border: "none", outline: "none", flexGrow: 1 }}
-              />
-            </Box>
-            <Box mt={2}>
-              <Button type="submit" variant="contained" color="primary" fullWidth sx={{ padding: "12px" }}>
-                {loading ? "Processing..." : "Submit"}
-              </Button>
-            </Box>
-          </form>
-        </Paper>
-
-        {/* Show Status Messages */}
-        {statusMessage && (
-          <Typography variant="h6" sx={{ textAlign: "center", marginTop: "10px", color: "#00bcd4" }}>
-            {statusMessage}
-          </Typography>
-        )}
-
-        {/* Show Loading Spinner */}
-        {loading && (
-          <Box sx={{ textAlign: "center", marginTop: "20px" }}>
-            <CircularProgress sx={{ color: "#ffffff" }} />
-          </Box>
-        )}
-
-        {/* Extracted Context */}
-        {context && (
-          <Box mt={4}>
-            <Typography variant="h6" gutterBottom>
-              Extracted Context:
-            </Typography>
-            <Paper
-              elevation={2}
-              sx={{
-                padding: "20px",
-                height: "300px",
-                overflowY: "scroll",
-                backgroundColor: "#333",
-                borderRadius: "10px",
-              }}
-            >
-              <Typography variant="body1">{context}</Typography>
-            </Paper>
-          </Box>
-        )}
-
-        {/* Generated Questions */}
-        {questions.length > 0 && (
-          <Box mt={4}>
-            <Typography variant="h6" gutterBottom>
-              Generated Questions:
-            </Typography>
-            <Grid container spacing={3}>
-              {questions.map((item, index) => (
-                <Grid item xs={12} sm={6} key={index}>
-                  <Card
-                    sx={{
-                      padding: "15px",
-                      borderRadius: 3,
-                      transition: "transform 0.3s, box-shadow 0.3s",
-                      "&:hover": {
-                        transform: "scale(1.05)",
-                        boxShadow: 6,
-                      },
-                    }}
-                  >
-                    <CardContent>
-                      <Typography variant="h6" sx={{ color: "#00bcd4", fontWeight: "bold" }}>
-                        <strong>Question {index + 1}:</strong> {item.question}
-                      </Typography>
-                      <Typography variant="body2">
-                        <strong style={{ color: "green" }}>Correct Answer:</strong> {item.schema.correct_answer}
-                      </Typography>
-                      <Typography variant="body2">
-                        <strong style={{ color: "#3f51b5" }}>Explanation:</strong> {item.schema.explanation}
-                      </Typography>
-                      <Typography variant="body2">
-                        <strong style={{ color: "#ffeb3b" }}>Hints:</strong>
-                        <List>
-                          {item.schema.hints.map((hint, i) => (
-                            <ListItem key={i}>
-                              <ListItemText primary={`${i + 1}. ${hint}`} />
-                            </ListItem>
-                          ))}
-                        </List>
-                      </Typography>
-                      <Typography variant="body2">
-                        <strong style={{ color: "#f44336" }}>Wrong Answers:</strong>
-                        <List>
-                          {item.schema.wrong_answers.map((wrong, i) => (
-                            <ListItem key={i}>
-                              <ListItemText primary={`${i + 1}. ${wrong}`} />
-                            </ListItem>
-                          ))}
-                        </List>
-                      </Typography>
-                    </CardContent>
-                  </Card>
-                </Grid>
-              ))}
-            </Grid>
-          </Box>
-        )}
-
-        {/* Snackbar for Status Updates */}
-        <Snackbar
-          open={openSnackbar}
-          autoHideDuration={3000}
-          onClose={() => setOpenSnackbar(false)}
-          message={statusMessage || error}
-          anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-        />
-      </Container>
-    </ThemeProvider>
+    <Router>
+      <AppBar position="static">
+        <Toolbar>
+          <Button color="inherit" component={Link} to="/">
+            Home
+          </Button>
+          <Button color="inherit" component={Link} to="/trivia">
+            Trivia
+          </Button>
+          <Button color="inherit" component={Link} to="/meshy">
+            Meshy
+          </Button>
+          <Button color="inherit" component={Link} to="/obstacles">
+            Obstacles
+          </Button>
+        </Toolbar>
+      </AppBar>
+      <Routes>
+        <Route path="/" element={<div style={{ padding: 20 }}>Select a feature from the navbar.</div>} />
+        <Route path="/trivia" element={<TriviaPage />} />
+        <Route path="/meshy" element={<MeshyPage />} />
+        <Route path="/obstacles" element={<ObstaclePage />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/material-kit-react/src/components/DownloadLinks.js
+++ b/material-kit-react/src/components/DownloadLinks.js
@@ -1,0 +1,59 @@
+import React from "react";
+
+const DownloadLinks = ({ modelUrls }) => {
+  return (
+    <div className="download-links">
+      <h3>Download 3D Model Files:</h3>
+      {modelUrls.glb && (
+        <p>
+          <a
+            href={modelUrls.glb}
+            target="_blank"
+            rel="noopener noreferrer"
+            download
+          >
+            Download GLB
+          </a>
+        </p>
+      )}
+      {modelUrls.obj && (
+        <p>
+          <a
+            href={modelUrls.obj}
+            target="_blank"
+            rel="noopener noreferrer"
+            download
+          >
+            Download OBJ
+          </a>
+        </p>
+      )}
+      {modelUrls.fbx && (
+        <p>
+          <a
+            href={modelUrls.fbx}
+            target="_blank"
+            rel="noopener noreferrer"
+            download
+          >
+            Download FBX
+          </a>
+        </p>
+      )}
+      {modelUrls.usdz && (
+        <p>
+          <a
+            href={modelUrls.usdz}
+            target="_blank"
+            rel="noopener noreferrer"
+            download
+          >
+            Download USDZ
+          </a>
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default DownloadLinks;

--- a/material-kit-react/src/components/Preview.js
+++ b/material-kit-react/src/components/Preview.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+const Preview = ({ thumbnailUrl }) => {
+  return (
+    <div>
+      {thumbnailUrl && (
+        <img
+          src={thumbnailUrl}
+          alt="3D Model Preview"
+          style={{ maxWidth: "300px", marginTop: "10px" }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default Preview;

--- a/material-kit-react/src/components/RefineButton.js
+++ b/material-kit-react/src/components/RefineButton.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+const RefineButton = ({ onClick, isLoading, countdown }) => {
+  return (
+    <button className="refine" onClick={onClick} disabled={isLoading}>
+      {isLoading ? `Refining... (${countdown} seconds)` : "Refine 3D Model"}
+    </button>
+  );
+};
+
+export default RefineButton;

--- a/material-kit-react/src/index.js
+++ b/material-kit-react/src/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import * as ReactDOMClient from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+
 import { CssBaseline, ThemeProvider } from "@mui/material";
 import App from "./App"; // Assuming App.js is in the same folder
 import theme from "./theme"; // Import the theme from theme.js
@@ -13,12 +13,11 @@ if (container) {
   const root = ReactDOMClient.createRoot(container);
 
   root.render(
-    <BrowserRouter>
+      
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <App />
       </ThemeProvider>
-    </BrowserRouter>
   );
 } else {
   console.error("Root container not found in the DOM.");

--- a/material-kit-react/src/pages/MeshyPage.js
+++ b/material-kit-react/src/pages/MeshyPage.js
@@ -1,0 +1,175 @@
+import React, { useState, useEffect } from "react";
+import Preview from "../components/Preview";
+import RefineButton from "../components/RefineButton";
+import DownloadLinks from "../components/DownloadLinks";
+
+const API_KEY = process.env.REACT_APP_MESHY_KEY;
+
+function MeshyPage() {
+  const [prompt, setPrompt] = useState("");
+  const [previewTaskId, setPreviewTaskId] = useState(null);
+  const [modelDataArray, setModelDataArray] = useState([]);
+  const [resultMessage, setResultMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isRefineVisible, setIsRefineVisible] = useState(false);
+  const [countdown, setCountdown] = useState(90);
+  const [isTakingLong, setIsTakingLong] = useState(false);
+
+  useEffect(() => {
+    let timer;
+    if (isLoading && countdown > 0) {
+      timer = setInterval(() => setCountdown((p) => p - 1), 1000);
+    } else if (countdown === 0) {
+      setIsTakingLong(true);
+    }
+    return () => clearInterval(timer);
+  }, [isLoading, countdown]);
+
+  const generate3DModel = () => {
+    if (!prompt) {
+      alert("Please enter a description for the 3D model.");
+      return;
+    }
+
+    setResultMessage("Generating 3D model...");
+    setIsLoading(true);
+    setCountdown(90);
+    setIsTakingLong(false);
+
+    const url = "https://api.meshy.ai/v2/text-to-3d";
+    fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        mode: "preview",
+        prompt,
+        art_style: "realistic",
+        negative_prompt: "low quality, low resolution, low poly, ugly",
+      }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        setPreviewTaskId(data.result);
+        const check = setInterval(() => {
+          fetch(`${url}/${data.result}`, {
+            headers: { Authorization: `Bearer ${API_KEY}` },
+          })
+            .then((r) => r.json())
+            .then((task) => {
+              if (task.status === "SUCCEEDED") {
+                clearInterval(check);
+                setModelDataArray((prev) => [
+                  ...prev,
+                  {
+                    modelUrls: task.model_urls,
+                    thumbnailUrl: task.thumbnail_url,
+                  },
+                ]);
+                setResultMessage("3D model generated successfully!");
+                setIsRefineVisible(true);
+                setIsLoading(false);
+                setIsTakingLong(false);
+              } else if (task.status === "FAILED") {
+                clearInterval(check);
+                setResultMessage("Failed to generate 3D model.");
+                setIsLoading(false);
+              }
+            });
+        }, 5000);
+      })
+      .catch((err) => {
+        console.error("Error:", err);
+        setResultMessage("Error generating 3D model. Please try again.");
+        setIsLoading(false);
+      });
+  };
+
+  const refine3DModel = () => {
+    setResultMessage("Refining 3D model...");
+    setIsLoading(true);
+    setCountdown(90);
+    setIsTakingLong(false);
+
+    const url = "https://api.meshy.ai/v2/text-to-3d";
+    fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        mode: "refine",
+        preview_task_id: previewTaskId,
+        texture_richness: "high",
+      }),
+    })
+      .then((res) => res.json())
+      .then((refineData) => {
+        const refineTaskId = refineData.result;
+        const checkRefine = setInterval(() => {
+          fetch(`${url}/${refineTaskId}`, {
+            headers: { Authorization: `Bearer ${API_KEY}` },
+          })
+            .then((r) => r.json())
+            .then((task) => {
+              if (task.status === "SUCCEEDED") {
+                clearInterval(checkRefine);
+                setModelDataArray((prev) => [
+                  ...prev,
+                  {
+                    modelUrls: task.model_urls,
+                    thumbnailUrl: task.thumbnail_url,
+                  },
+                ]);
+                setResultMessage("Refined model successfully generated!");
+                setIsLoading(false);
+                setIsTakingLong(false);
+              } else if (task.status === "FAILED") {
+                clearInterval(checkRefine);
+                setResultMessage("Failed to refine 3D model.");
+                setIsLoading(false);
+              }
+            });
+        }, 5000);
+      })
+      .catch((err) => {
+        console.error("Error refining 3D model:", err);
+        setResultMessage("Error refining 3D model. Please try again.");
+        setIsLoading(false);
+      });
+  };
+
+  return (
+    <div className="container" style={{ maxWidth: 600, margin: "0 auto" }}>
+      <h1>Generate 3D Model from Text</h1>
+      <input
+        type="text"
+        value={prompt}
+        placeholder="Enter description for 3D model..."
+        onChange={(e) => setPrompt(e.target.value)}
+        style={{ width: "100%", padding: 10, margin: "10px 0" }}
+      />
+      <button onClick={generate3DModel} disabled={isLoading} style={{ padding: "10px 20px" }}>
+        {isLoading ? `Loading... (${countdown} seconds)` : "Generate 3D Model"}
+      </button>
+      {isRefineVisible && (
+        <RefineButton onClick={refine3DModel} isLoading={isLoading} countdown={countdown} />
+      )}
+      <div className="result" style={{ marginTop: 20 }}>
+        <p>{isTakingLong ? "Taking longer than expected..." : resultMessage}</p>
+        {modelDataArray.length > 0 &&
+          modelDataArray.map((modelData, index) => (
+            <div key={index}>
+              <Preview thumbnailUrl={modelData.thumbnailUrl} />
+              <DownloadLinks modelUrls={modelData.modelUrls} />
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+export default MeshyPage;

--- a/material-kit-react/src/pages/ObstaclePage.js
+++ b/material-kit-react/src/pages/ObstaclePage.js
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+import axios from "axios";
+
+function ObstaclePage() {
+  const [prompt, setPrompt] = useState("");
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!prompt) return;
+    setLoading(true);
+    setError("");
+    try {
+      const res = await axios.post("http://127.0.0.1:5000/runBlender", { prompt });
+      setResult(res.data);
+    } catch (err) {
+      setError("Failed to generate obstacle");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Obstacle Generator</h1>
+      <form onSubmit={handleSubmit} style={{ marginBottom: 20 }}>
+        <input
+          type="text"
+          value={prompt}
+          placeholder="Enter obstacle description"
+          onChange={(e) => setPrompt(e.target.value)}
+          style={{ width: "100%", padding: 10, marginBottom: 10 }}
+        />
+        <button type="submit" disabled={loading} style={{ padding: "10px 20px" }}>
+          {loading ? "Generating..." : "Generate"}
+        </button>
+      </form>
+      {error && <p style={{ color: "red" }}>{error}</p>}
+      {result && (
+        <div>
+          <p>Object Name: {result.objectName}</p>
+          <a href={result.fileUrl} target="_blank" rel="noopener noreferrer">
+            Download GLB
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ObstaclePage;

--- a/material-kit-react/src/pages/TriviaPage.js
+++ b/material-kit-react/src/pages/TriviaPage.js
@@ -1,0 +1,326 @@
+import React, { useState } from "react";
+import axios from "axios";
+import {
+  Button,
+  Typography,
+  Container,
+  Box,
+  Paper,
+  CircularProgress,
+  Alert,
+  Grid,
+  Card,
+  CardContent,
+  List,
+  ListItem,
+  ListItemText,
+  AppBar,
+  Toolbar,
+  IconButton,
+  Avatar,
+  Snackbar,
+  Skeleton,
+} from "@mui/material";
+import { CloudUpload as CloudUploadIcon, Menu as MenuIcon } from "@mui/icons-material";
+import { createTheme, ThemeProvider } from "@mui/material/styles";
+import { motion } from "framer-motion";
+import Logo from "../assets/images/LV (2).png"; // Correct path for logo
+
+const theme = createTheme({
+  palette: {
+    mode: "dark",
+    primary: {
+      main: "#00bcd4",
+    },
+    secondary: {
+      main: "#ff4081",
+    },
+    background: {
+      default: "#121212",
+      paper: "rgba(255, 255, 255, 0.08)",
+    },
+  },
+  typography: {
+    fontFamily: "Poppins, Arial, sans-serif",
+    h6: {
+      fontWeight: 700,
+    },
+  },
+});
+
+function TriviaPage() {
+  const [file, setFile] = useState(null);
+  const [context, setContext] = useState("");
+  const [questions, setQuestions] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [statusMessage, setStatusMessage] = useState("");
+  const [error, setError] = useState("");
+  const [openSnackbar, setOpenSnackbar] = useState(false);
+
+  const handleFileChange = (event) => {
+    setFile(event.target.files[0]);
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!file) {
+      alert("Please upload a file!");
+      return;
+    }
+
+    setLoading(true);
+    setStatusMessage("Extracting text from PDF...");
+    setError("");
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const response = await axios.post("http://127.0.0.1:5000/process-pdf", formData, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      });
+
+      if (response.data.status === "text_extracted") {
+        setStatusMessage("Text extracted successfully!");
+        setContext(response.data.context);
+
+        setStatusMessage("Generating questions...");
+        const questionResponse = await axios.post(
+          "http://127.0.0.1:5000/generate-questions",
+          { context: response.data.context }
+        );
+
+        if (questionResponse.data.status === "questions_generated") {
+          setStatusMessage("Questions generated successfully!");
+          setQuestions(questionResponse.data.questions);
+        } else {
+          setStatusMessage("Failed to generate questions.");
+        }
+      }
+    } catch (error) {
+      console.error("Error processing PDF:", error);
+      setStatusMessage("");
+      setError("Failed to process PDF!");
+    } finally {
+      setLoading(false);
+      setOpenSnackbar(true);
+    }
+  };
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Container maxWidth="md" sx={{ padding: "20px", borderRadius: 2 }}>
+        {/* Navbar */}
+        <AppBar position="static" sx={{ marginBottom: "20px", backgroundColor: "#181818", padding: "20px 0" }}>
+  <Toolbar sx={{ flexDirection: "column", alignItems: "center" }}>
+    {/* Logo */}
+    <>
+  {/* Keyframes for Animation */}
+  <style>
+    {`
+      @keyframes pulse {
+        0% {
+          transform: scale(1);
+        }
+        50% {
+          transform: scale(1.1);
+        }
+        100% {
+          transform: scale(1);
+        }
+      }
+    `}
+  </style>
+
+  <img
+    src={Logo}
+    alt="Logo"
+    style={{
+      width: "60px",
+      marginBottom: "10px",
+      animation: "pulse 2s infinite ease-in-out",
+    }}
+  />
+</>
+
+
+    {/* Title */}
+    <Typography
+  variant="h4"
+  component={motion.div}
+  initial={{ opacity: 0, scale: 0.8 }}
+  animate={{ opacity: 1, scale: 1 }}
+  transition={{ duration: 0.5 }}
+  sx={{
+    fontWeight: "bold",
+    fontSize: "2.5rem",
+    background: "linear-gradient(90deg, #1E90FF, #00BFFF, #87CEFA)", // Updated colors
+    WebkitBackgroundClip: "text",
+    WebkitTextFillColor: "transparent",
+    textAlign: "center",
+    textShadow: "0px 0px 10px rgba(30, 144, 255, 0.6), 0px 0px 10px rgba(0, 191, 255, 0.6)", // Matches website theme
+    border: "2px solid rgba(255, 255, 255, 0.1)",
+    borderRadius: "10px",
+    padding: "10px 20px",
+  }}
+>
+  Lidvizion's Trivia Generator
+</Typography>
+
+
+
+
+
+  </Toolbar>
+</AppBar>
+
+
+
+
+        {/* File Upload Section */}
+        <Paper elevation={4} sx={{ padding: "30px", marginBottom: "30px", borderRadius: 3 }}>
+          <Typography
+            variant="h6"
+            gutterBottom
+            component={motion.div}
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            Upload a PDF to Generate Trivia Questions
+          </Typography>
+          <form onSubmit={handleSubmit}>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                border: "1px solid #ccc",
+                padding: "10px",
+                borderRadius: "5px",
+              }}
+            >
+              <CloudUploadIcon sx={{ marginRight: "10px" }} />
+              <input
+                type="file"
+                accept="application/pdf"
+                onChange={handleFileChange}
+                style={{ border: "none", outline: "none", flexGrow: 1 }}
+              />
+            </Box>
+            <Box mt={2}>
+              <Button type="submit" variant="contained" color="primary" fullWidth sx={{ padding: "12px" }}>
+                {loading ? "Processing..." : "Submit"}
+              </Button>
+            </Box>
+          </form>
+        </Paper>
+
+        {/* Show Status Messages */}
+        {statusMessage && (
+          <Typography variant="h6" sx={{ textAlign: "center", marginTop: "10px", color: "#00bcd4" }}>
+            {statusMessage}
+          </Typography>
+        )}
+
+        {/* Show Loading Spinner */}
+        {loading && (
+          <Box sx={{ textAlign: "center", marginTop: "20px" }}>
+            <CircularProgress sx={{ color: "#ffffff" }} />
+          </Box>
+        )}
+
+        {/* Extracted Context */}
+        {context && (
+          <Box mt={4}>
+            <Typography variant="h6" gutterBottom>
+              Extracted Context:
+            </Typography>
+            <Paper
+              elevation={2}
+              sx={{
+                padding: "20px",
+                height: "300px",
+                overflowY: "scroll",
+                backgroundColor: "#333",
+                borderRadius: "10px",
+              }}
+            >
+              <Typography variant="body1">{context}</Typography>
+            </Paper>
+          </Box>
+        )}
+
+        {/* Generated Questions */}
+        {questions.length > 0 && (
+          <Box mt={4}>
+            <Typography variant="h6" gutterBottom>
+              Generated Questions:
+            </Typography>
+            <Grid container spacing={3}>
+              {questions.map((item, index) => (
+                <Grid item xs={12} sm={6} key={index}>
+                  <Card
+                    sx={{
+                      padding: "15px",
+                      borderRadius: 3,
+                      transition: "transform 0.3s, box-shadow 0.3s",
+                      "&:hover": {
+                        transform: "scale(1.05)",
+                        boxShadow: 6,
+                      },
+                    }}
+                  >
+                    <CardContent>
+                      <Typography variant="h6" sx={{ color: "#00bcd4", fontWeight: "bold" }}>
+                        <strong>Question {index + 1}:</strong> {item.question}
+                      </Typography>
+                      <Typography variant="body2">
+                        <strong style={{ color: "green" }}>Correct Answer:</strong> {item.schema.correct_answer}
+                      </Typography>
+                      <Typography variant="body2">
+                        <strong style={{ color: "#3f51b5" }}>Explanation:</strong> {item.schema.explanation}
+                      </Typography>
+                      <Typography variant="body2">
+                        <strong style={{ color: "#ffeb3b" }}>Hints:</strong>
+                        <List>
+                          {item.schema.hints.map((hint, i) => (
+                            <ListItem key={i}>
+                              <ListItemText primary={`${i + 1}. ${hint}`} />
+                            </ListItem>
+                          ))}
+                        </List>
+                      </Typography>
+                      <Typography variant="body2">
+                        <strong style={{ color: "#f44336" }}>Wrong Answers:</strong>
+                        <List>
+                          {item.schema.wrong_answers.map((wrong, i) => (
+                            <ListItem key={i}>
+                              <ListItemText primary={`${i + 1}. ${wrong}`} />
+                            </ListItem>
+                          ))}
+                        </List>
+                      </Typography>
+                    </CardContent>
+                  </Card>
+                </Grid>
+              ))}
+            </Grid>
+          </Box>
+        )}
+
+        {/* Snackbar for Status Updates */}
+        <Snackbar
+          open={openSnackbar}
+          autoHideDuration={3000}
+          onClose={() => setOpenSnackbar(false)}
+          message={statusMessage || error}
+          anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        />
+      </Container>
+    </ThemeProvider>
+  );
+}
+
+export default TriviaPage;


### PR DESCRIPTION
## Summary
- consolidate routes for Trivia, Meshy and Obstacle pages inside `App.js`
- add environment sample for Meshy
- document local setup for the new unified React frontend
- outline unified app usage in the repo README

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fc7a9c11883259196a75970850986